### PR TITLE
Update BUCC and fix env var casing for new version

### DIFF
--- a/envs/bucc/bin/env
+++ b/envs/bucc/bin/env
@@ -5,8 +5,8 @@ set -eu
 ENVDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ENVDIR/../..
 
-export bucc_project_root=${ENVDIR}
+export BUCC_PROJECT_ROOT=${ENVDIR}
 cat <<EOS
-export bucc_project_root=${ENVDIR}
+export BUCC_PROJECT_ROOT=${ENVDIR}
 $(src/bucc/bin/bucc env)
 EOS

--- a/envs/bucc/bin/update
+++ b/envs/bucc/bin/update
@@ -6,7 +6,7 @@ ENVDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 envname=$(basename $ENVDIR)
 echo "Updating $envname..."
 
-export bucc_project_root=$ENVDIR
+export BUCC_PROJECT_ROOT=$ENVDIR
 cd $ENVDIR/../..
 
 source <(src/bucc/bin/bucc env)
@@ -32,5 +32,5 @@ if [[ "${action}" == "up" ]]; then
     -o <($ENVDIR/cloud-config-operators/cloud-config-spot-reservation.sh) \
     -l <($ENVDIR/cloud-config-operators/vars-from-terraform.sh)
 
-  bosh upload-stemcell https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+  bosh upload-stemcell https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent
 fi


### PR DESCRIPTION
Hey Stark and Wayne people, thanks for the great demo and the video that accompanies this. I recently ran through this and noticed it was building Ubuntu Trusty BOSH hosts (Trusty as I'm sure you know is EOL in a month). A little poking around and it turned out the BUCC submodule just needed an update. But once that was done I discovered that the environment variable casing had changed. This fixes it. I successfully stood up the BOSH director/UAA/CredHub/Concourse piece of this stack that way. I personally am not using the jump box portion so I did not validate that part of it.